### PR TITLE
Cookie Bar and GTM scripts

### DIFF
--- a/src/themes/book2/assets/cookie-bar.js
+++ b/src/themes/book2/assets/cookie-bar.js
@@ -1,0 +1,74 @@
+(function() {
+  /*
+  cookie-bar.js
+  1. Show if 'cookie consent yes' is not set to 'true' in localStorage
+  2. remove h3 heading on scroll
+  3. mobile responsive padding (#main element). Handle docs page sidebars also.
+  4. button click sets 'redsift/gave-cookie-consent' flag in localStorage
+  */
+
+  const body = document.querySelector("body");
+  const main = document.querySelector("#main");
+  const cookieBar = document.querySelector("#cookie-bar");
+  const cookieHeading = document.querySelector("#cookie-heading");
+  const cookieButton = document.querySelector("#cookie-button");
+
+  const gaveConsent = localStorage.getItem("redsift/gave-cookie-consent");
+
+  const setDocsPadding = () => {
+    if (body.classList.contains("fixed-position") && !gaveConsent && window.innerWidth >= 768) {
+      const left = document.querySelector("#left-sidebar");
+      const right = document.querySelector("#right-sidebar");
+      left.style.top = `${cookieBar.clientHeight}px`;
+      right.style.top = `${77 + cookieBar.clientHeight}px`;
+    }
+  }
+
+  const setPadding = () => {
+    if (!gaveConsent) {
+      let mainPaddingTop = 72;
+      if (window.innerWidth < 768){
+        mainPaddingTop = 63;
+      }
+      cookieBar.classList.remove("hide");
+      main.style.paddingTop = `${cookieBar.clientHeight + mainPaddingTop}px`;
+      setDocsPadding();
+    }
+  }
+
+  const hideHeading = () => {
+    if (window.scrollY >= 80) {
+      cookieHeading.classList.add("hide");
+    } else {
+      cookieHeading.classList.remove("hide");
+    }
+  }
+
+  const hideBar = () => {
+    localStorage.setItem("redsift/gave-cookie-consent", "yes");
+    cookieBar.classList.add("hide");
+    main.style.removeProperty('padding-top');
+    // docs padding reset
+    if (body.classList.contains("fixed-position") && window.innerWidth >= 768) {
+      const left = document.querySelector("#left-sidebar");
+      const right = document.querySelector("#right-sidebar");
+      left.style.removeProperty('top');
+      right.style.removeProperty('top');
+    }
+  }
+
+  setPadding();
+  setDocsPadding();
+  cookieButton.onclick = hideBar;
+
+  window.addEventListener('resize', () => {
+    setPadding();
+    setDocsPadding();
+  });
+
+  window.addEventListener('scroll', () => {
+    hideHeading();
+    setDocsPadding();
+  });
+
+})();

--- a/src/themes/book2/assets/scss/base/_cookie-bar.scss
+++ b/src/themes/book2/assets/scss/base/_cookie-bar.scss
@@ -1,0 +1,59 @@
+.header-container {
+  position: fixed;
+  top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 3;
+}
+
+.cookie-bar {
+  background-color: $blue-black;
+  &.hide {
+    display: none;
+  }
+
+  .container {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    h3 {
+      text-align: left;
+      font-size: 1.25rem;;
+      color: white;
+      margin-bottom: 0.5rem;
+      &.hide {
+        display: none;
+      }
+    }
+
+    p, a {
+      font-size: 14px;
+    }
+    p {
+      margin-top: 0;
+      color: $light-purple;
+    }
+    button {
+      border: none;
+      width: 100%;
+      @media only screen and (min-width: 480px) {
+        width: auto;
+      }
+    }
+  }
+}
+
+.cookie-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  @media only screen and (min-width: 1024px) {
+    justify-content: space-between;
+    &.scrolled {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
+  .hide {
+    display: none;
+  }
+}

--- a/src/themes/book2/assets/scss/base/_helpers.scss
+++ b/src/themes/book2/assets/scss/base/_helpers.scss
@@ -98,7 +98,7 @@
 	letter-spacing: 1.61px;
 	padding: 115px 30px 15px;
 	margin: 0 -15px;
-	background: #0d0d1a;
+	background: $blue-black;
 	box-shadow: 0 5px 20px rgba(13, 13, 26, .5);
 	border-top: 4px solid $light-blue;
 	color: #fff;

--- a/src/themes/book2/assets/scss/base/_variables.scss
+++ b/src/themes/book2/assets/scss/base/_variables.scss
@@ -11,7 +11,7 @@ $dark-purple: #2a2a41;
 $orange: #fcbb54;
 $light-blue: #53c5ee;
 $dark-blue: #181825;
-
+$blue-black: #0d0d1a;
 
 $base-font-sans-serif: 'Raleway', 'Helvetica Neue', 'Helvetica', sans-serif;
 $base-font-serif: 'Times New Roman', 'Times', 'Baskerville', 'Georgia', serif;

--- a/src/themes/book2/assets/scss/layouts/_header.scss
+++ b/src/themes/book2/assets/scss/layouts/_header.scss
@@ -3,11 +3,11 @@
 	padding: 16px 0;
 	background: $dark-blue;
 	position: relative;
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 3;
+	// position: fixed;
+	// top: 0;
+	// left: 0;
+	// width: 100%;
+	// z-index: 3;
 	@include media ('>=tablet') {
 		padding: 10px 0;
 	}

--- a/src/themes/book2/assets/scss/layouts/landing/_integration-section.scss
+++ b/src/themes/book2/assets/scss/layouts/landing/_integration-section.scss
@@ -61,7 +61,7 @@
 		height: 100%;
 		padding: 10px;
 		background: $dark-blue;
-		box-shadow: 0 5px 9px #0d0d1a;
+		box-shadow: 0 5px 9px $blue-black;
 		border: 1px solid $dark-blue;
 
 		@include media ('>=tablet') {

--- a/src/themes/book2/assets/scss/layouts/landing/_uses-section.scss
+++ b/src/themes/book2/assets/scss/layouts/landing/_uses-section.scss
@@ -195,7 +195,7 @@
 	.slide {
 		display: none;
 		padding: 30px 10px 5px 32px;
-		background: #0d0d1a;
+		background: $blue-black;
 
 		@include media ('>=tablet') {
 			display: block;

--- a/src/themes/book2/assets/scss/main.scss
+++ b/src/themes/book2/assets/scss/main.scss
@@ -31,6 +31,7 @@ $media-expressions: (
 @import 'base/reset';
 @import 'base/typography';
 @import 'base/forms';
+@import 'base/cookie-bar';
 
 @import 'layouts/header';
 @import 'layouts/footer';

--- a/src/themes/book2/layouts/404.html
+++ b/src/themes/book2/layouts/404.html
@@ -7,6 +7,10 @@
   </head>
 
   <body class="fixed-position">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRMND9W"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
     <div id="wrapper">
       {{ template "header" . }}
       <main id="main">

--- a/src/themes/book2/layouts/partials/common/cookie-bar.html
+++ b/src/themes/book2/layouts/partials/common/cookie-bar.html
@@ -1,0 +1,14 @@
+<div id="cookie-bar" class="cookie-bar hide">
+  <div class="container">
+    <h3 id="cookie-heading">This site uses cookies</h3>
+    <div class="cookie-content">
+      <p>
+        <span class="short">We’re using cookies to give you the best experience across our websites and products.
+        For more information, </span>
+        <!-- <span class="long hide">We’re using cookies to give you the best experience across our websites and products.
+        For more information on how we use cookies and how to disable them, </span> -->
+        visit our <a href="https://redsift.com/cookies" target="_blank" rel="noopener noreferrer">Cookies policy</a></p>
+      <button id="cookie-button" type="button" class="btn">Accept and continue</button>
+    </div>
+  </div>
+</div>

--- a/src/themes/book2/layouts/partials/common/header.html
+++ b/src/themes/book2/layouts/partials/common/header.html
@@ -1,30 +1,34 @@
-<a class="accessibility" href="#main">Skip to Content</a>
-<header id="header">
-  <div class="container">
-    <!-- page logo -->
-    <strong class="logo">
-      <a href="/">
-        {{- with .Site.Params.BookLogo -}}
-        <img src="{{ . | relURL }}" alt="ingraind" width="135"/>
-        {{- end -}}
-      </a>
-    </strong>
-    <!-- main navigation opener -->
-    <a class="nav-opener" href="#">nav-opener<span></span></a>
-    <div class="drop">
-      <!-- main navigation of the page -->
-      <nav class="nav main-menu">
-        {{ partial "docs/inject/menu-before" . }}
-        {{ partial "docs/menu-hugo" .Site.Menus.before }}
+{{ define "cookie-bar" }} {{ partial "common/cookie-bar" . }} {{ end }}
+<div class="header-container">
+  {{ template "cookie-bar" . }}
+  <a class="accessibility" href="#main">Skip to Content</a>
+  <header id="header">
+    <div class="container">
+      <!-- page logo -->
+      <strong class="logo">
+        <a href="/">
+          {{- with .Site.Params.BookLogo -}}
+          <img src="{{ . | relURL }}" alt="ingraind" width="135"/>
+          {{- end -}}
+        </a>
+      </strong>
+      <!-- main navigation opener -->
+      <a class="nav-opener" href="#">nav-opener<span></span></a>
+      <div class="drop">
+        <!-- main navigation of the page -->
+        <nav class="nav main-menu">
+          {{ partial "docs/inject/menu-before" . }}
+          {{ partial "docs/menu-hugo" .Site.Menus.before }}
 
-        {{ if .Site.Params.MainMenuBundle }}
-          {{ partial "common/main-menu-bundle" . }}
-        {{ end }}
+          {{ if .Site.Params.MainMenuBundle }}
+            {{ partial "common/main-menu-bundle" . }}
+          {{ end }}
 
-        {{ partial "docs/menu-hugo" .Site.Menus.after }}
-        {{ partial "docs/inject/menu-after" . }}
-      </nav>
-      {{ template "social" . }}
+          {{ partial "docs/menu-hugo" .Site.Menus.after }}
+          {{ partial "docs/inject/menu-after" . }}
+        </nav>
+        {{ template "social" . }}
+      </div>
     </div>
-  </div>
-</header>
+  </header>
+</div>

--- a/src/themes/book2/layouts/partials/common/html-head.html
+++ b/src/themes/book2/layouts/partials/common/html-head.html
@@ -9,9 +9,21 @@
 <title>{{ partial "docs/title" . }} | {{ .Site.Title -}}</title>
 <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/x-icon">
 
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-WRMND9W');</script>
+  <!-- End Google Tag Manager -->
+
 <!-- Theme stylesheet, you can customize scss by creating `assets/custom.scss` in your website -->
 {{- $styles := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+
+{{- $cookieJSFile := printf "%s.cookie-bar.js" .Language.Lang -}}
+{{- $cookieJS := resources.Get "cookie-bar.js" | resources.ExecuteAsTemplate $cookieJSFile . | resources.Minify | resources.Fingerprint }}
+<script defer src="{{ $cookieJS.RelPermalink }}" integrity="{{ $cookieJS.Data.Integrity }}"></script>
 
 {{ if default true .Site.Params.BookSearch }}
 {{- $menuJSFile := printf "%s.menu-toggle.js" .Language.Lang -}}

--- a/src/themes/book2/layouts/partials/docs/basedoc.html
+++ b/src/themes/book2/layouts/partials/docs/basedoc.html
@@ -39,6 +39,10 @@
 {{ end }}
 
 <body class="fixed-position">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRMND9W"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
 	<div id="wrapper">
 		{{ template "header" . }}
 
@@ -47,7 +51,7 @@
 			<div class="container inner-container">
 				<!-- sidebar -->
 				<aside class="sidebar">
-				  <div class="fixed-block">
+				  <div id="left-sidebar" class="fixed-block">
 				    {{ template "menu" . }} <!-- Left menu Content -->
 				  </div>
 				</aside>
@@ -55,10 +59,10 @@
 				<div class="content">
 				  {{ template "main" . }} <!-- Page Content -->
 				</div>
-				<!-- aside -->
+				<!-- right-sidebar -->
 				{{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
 				<aside class="aside hide">
-					<div class="fixed-block">
+					<div id="right-sidebar" class="fixed-block">
 					  <h3>Contents</h3>
 					  {{ template "toc" . }} <!-- Table of Contents -->
 					</div>

--- a/src/themes/book2/layouts/partials/landing.html
+++ b/src/themes/book2/layouts/partials/landing.html
@@ -14,6 +14,10 @@
 {{ define "footer" }} {{ partial "common/footer" . }} {{ end }}
 
 <body class="home-page">
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRMND9W"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <!-- main container of all the page elements -->
   <div id="wrapper">
     {{ template "header" . }}


### PR DESCRIPTION
- Similar cookie bar and action as used on redsift and ondmarc websites
- Requires extra setup in GTM to set cookies on `redsift/gave-cookie-consent` flag being set to 'yes' in localStorage, rather than just load