### PR TITLE
minor bugfixes for mobile

### DIFF
--- a/src/themes/book2/assets/cookie-bar.js
+++ b/src/themes/book2/assets/cookie-bar.js
@@ -68,7 +68,7 @@
 
   window.addEventListener('scroll', () => {
     hideHeading();
-    setDocsPadding();
+    setPadding();
   });
 
 })();

--- a/src/themes/book2/assets/scss/layouts/landing/_about-section.scss
+++ b/src/themes/book2/assets/scss/layouts/landing/_about-section.scss
@@ -1,5 +1,5 @@
 .about-section {
-	padding: 50px;
+	padding: 50px 0;
 	position: relative;
 
 	.container {


### PR DESCRIPTION
Minor bugs I spotted and fixed:
- About section at bottom too narrow
- Scroll down, and then scroll back up again. Can't view page title / heading without refreshing the page (hidden behind menu / header). Can't replicate in dev tools, need to test on phone, but I think this should fix it.